### PR TITLE
Pertf tests

### DIFF
--- a/move_test.go
+++ b/move_test.go
@@ -204,6 +204,73 @@ func TestPositionUpdates(t *testing.T) {
 	}
 }
 
+type perfTest struct {
+	pos           *Position
+	nodesPerDepth []int
+}
+
+/* https://www.chessprogramming.org/Perft_Results */
+var perfResults = []perfTest{
+	{pos: unsafeFEN("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"), nodesPerDepth: []int{
+		20, 400, 8902,
+		// 197281, 4865609, 119060324, 3195901860, 84998978956, 2439530234167, 69352859712417
+	}},
+	{pos: unsafeFEN("r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1"), nodesPerDepth: []int{
+		48, 2039,
+		// 97862, 4085603, 193690690
+	}},
+	{pos: unsafeFEN("8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8 w - - 0 1"), nodesPerDepth: []int{
+		14, 191, 2812,
+		// 43238, 674624, 11030083, 178633661
+	}},
+	{pos: unsafeFEN("r3k2r/Pppp1ppp/1b3nbN/nP6/BBP1P3/q4N2/Pp1P2PP/R2Q1RK1 w kq - 0 1"), nodesPerDepth: []int{
+		6, 264, 9467,
+		// 422333, 15833292, 706045033
+	}},
+	{pos: unsafeFEN("r2q1rk1/pP1p2pp/Q4n2/bbp1p3/Np6/1B3NBn/pPPP1PPP/R3K2R b KQ - 0 1"), nodesPerDepth: []int{
+		6, 264, 9467,
+		// 422333, 15833292, 706045033
+	}},
+	{pos: unsafeFEN("rnbq1k1r/pp1Pbppp/2p5/8/2B5/8/PPP1NnPP/RNBQK2R w KQ - 1 8"), nodesPerDepth: []int{
+		44, 1486,
+		// 62379, 2103487, 89941194
+	}},
+	{pos: unsafeFEN("r4rk1/1pp1qppp/p1np1n2/2b1p1B1/2B1P1b1/P1NP1N2/1PP1QPPP/R4RK1 w - - 0 10"), nodesPerDepth: []int{
+		46, 2079,
+		// 89890, 3894594, 164075551, 6923051137, 287188994746, 11923589843526, 490154852788714
+	}},
+}
+
+func TestPerfResults(t *testing.T) {
+	for _, perf := range perfResults {
+		countMoves(t, perf.pos, []*Position{perf.pos}, perf.nodesPerDepth, len(perf.nodesPerDepth))
+	}
+}
+
+func countMoves(t *testing.T, originalPosition *Position, positions []*Position, nodesPerDepth []int, max_depth int) {
+	if len(nodesPerDepth) == 0 {
+		return
+	}
+	depth := max_depth - len(nodesPerDepth) + 1
+	exp_nodes := nodesPerDepth[0]
+	newPositions := make([]*Position, 0)
+	for _, pos := range positions {
+		for _, move := range pos.ValidMoves() {
+			newPos := pos.copy()
+			newPos.Update(move)
+			newPositions = append(newPositions, newPos)
+		}
+	}
+	got_nodes := len(newPositions)
+	if exp_nodes != got_nodes {
+		t.Log(originalPosition.String())
+		t.Log(originalPosition.board.Draw())
+		t.Errorf("Depth: %d Expected: %d Got: %d", depth, exp_nodes, got_nodes)
+	}
+
+	countMoves(t, originalPosition, newPositions, nodesPerDepth[1:], max_depth)
+}
+
 func BenchmarkValidMoves(b *testing.B) {
 	pos := unsafeFEN("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1")
 	b.ResetTimer()

--- a/move_test.go
+++ b/move_test.go
@@ -212,32 +212,32 @@ type perfTest struct {
 /* https://www.chessprogramming.org/Perft_Results */
 var perfResults = []perfTest{
 	{pos: unsafeFEN("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"), nodesPerDepth: []int{
-		20, 400, 8902,
-		// 197281, 4865609, 119060324, 3195901860, 84998978956, 2439530234167, 69352859712417
+		20, 400, 8902, 197281,
+		// 4865609, 119060324, 3195901860, 84998978956, 2439530234167, 69352859712417
 	}},
 	{pos: unsafeFEN("r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1"), nodesPerDepth: []int{
-		48, 2039,
-		// 97862, 4085603, 193690690
+		48, 2039, 97862,
+		// 4085603, 193690690
 	}},
 	{pos: unsafeFEN("8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8 w - - 0 1"), nodesPerDepth: []int{
-		14, 191, 2812,
-		// 43238, 674624, 11030083, 178633661
+		14, 191, 2812, 43238, 674624,
+		// 11030083, 178633661
 	}},
 	{pos: unsafeFEN("r3k2r/Pppp1ppp/1b3nbN/nP6/BBP1P3/q4N2/Pp1P2PP/R2Q1RK1 w kq - 0 1"), nodesPerDepth: []int{
-		6, 264, 9467,
-		// 422333, 15833292, 706045033
+		6, 264, 9467, 422333,
+		// 15833292, 706045033
 	}},
 	{pos: unsafeFEN("r2q1rk1/pP1p2pp/Q4n2/bbp1p3/Np6/1B3NBn/pPPP1PPP/R3K2R b KQ - 0 1"), nodesPerDepth: []int{
-		6, 264, 9467,
-		// 422333, 15833292, 706045033
+		6, 264, 9467, 422333,
+		// 15833292, 706045033
 	}},
 	{pos: unsafeFEN("rnbq1k1r/pp1Pbppp/2p5/8/2B5/8/PPP1NnPP/RNBQK2R w KQ - 1 8"), nodesPerDepth: []int{
-		44, 1486,
-		// 62379, 2103487, 89941194
+		44, 1486, 62379,
+		// 2103487, 89941194
 	}},
 	{pos: unsafeFEN("r4rk1/1pp1qppp/p1np1n2/2b1p1B1/2B1P1b1/P1NP1N2/1PP1QPPP/R4RK1 w - - 0 10"), nodesPerDepth: []int{
-		46, 2079,
-		// 89890, 3894594, 164075551, 6923051137, 287188994746, 11923589843526, 490154852788714
+		46, 2079, 89890,
+		// 3894594, 164075551, 6923051137, 287188994746, 11923589843526, 490154852788714
 	}},
 }
 
@@ -256,8 +256,7 @@ func countMoves(t *testing.T, originalPosition *Position, positions []*Position,
 	newPositions := make([]*Position, 0)
 	for _, pos := range positions {
 		for _, move := range pos.ValidMoves() {
-			newPos := pos.copy()
-			newPos.Update(move)
+			newPos := pos.Update(move)
 			newPositions = append(newPositions, newPos)
 		}
 	}

--- a/move_test.go
+++ b/move_test.go
@@ -247,12 +247,12 @@ func TestPerfResults(t *testing.T) {
 	}
 }
 
-func countMoves(t *testing.T, originalPosition *Position, positions []*Position, nodesPerDepth []int, max_depth int) {
+func countMoves(t *testing.T, originalPosition *Position, positions []*Position, nodesPerDepth []int, maxDepth int) {
 	if len(nodesPerDepth) == 0 {
 		return
 	}
-	depth := max_depth - len(nodesPerDepth) + 1
-	exp_nodes := nodesPerDepth[0]
+	depth := maxDepth - len(nodesPerDepth) + 1
+	expNodes := nodesPerDepth[0]
 	newPositions := make([]*Position, 0)
 	for _, pos := range positions {
 		for _, move := range pos.ValidMoves() {
@@ -261,14 +261,14 @@ func countMoves(t *testing.T, originalPosition *Position, positions []*Position,
 			newPositions = append(newPositions, newPos)
 		}
 	}
-	got_nodes := len(newPositions)
-	if exp_nodes != got_nodes {
+	gotNodes := len(newPositions)
+	if expNodes != gotNodes {
 		t.Log(originalPosition.String())
 		t.Log(originalPosition.board.Draw())
-		t.Errorf("Depth: %d Expected: %d Got: %d", depth, exp_nodes, got_nodes)
+		t.Errorf("Depth: %d Expected: %d Got: %d", depth, expNodes, gotNodes)
 	}
 
-	countMoves(t, originalPosition, newPositions, nodesPerDepth[1:], max_depth)
+	countMoves(t, originalPosition, newPositions, nodesPerDepth[1:], maxDepth)
 }
 
 func BenchmarkValidMoves(b *testing.B) {

--- a/move_test.go
+++ b/move_test.go
@@ -262,11 +262,19 @@ func countMoves(t *testing.T, originalPosition *Position, positions []*Position,
 	}
 	gotNodes := len(newPositions)
 	if expNodes != gotNodes {
+		t.Errorf("Depth: %d Expected: %d Got: %d", depth, expNodes, gotNodes)
+		t.Log("##############################")
+		t.Log("# Original position info")
+		t.Log("###")
 		t.Log(originalPosition.String())
 		t.Log(originalPosition.board.Draw())
-		t.Errorf("Depth: %d Expected: %d Got: %d", depth, expNodes, gotNodes)
+		t.Log("##############################")
+		t.Log("# Details in JSONL (http://jsonlines.org)")
+		t.Log("###")
+		for _, pos := range positions {
+			t.Logf(`{"position": "%s", "moves": %d}`, pos.String(), len(pos.ValidMoves()))
+		}
 	}
-
 	countMoves(t, originalPosition, newPositions, nodesPerDepth[1:], maxDepth)
 }
 


### PR DESCRIPTION
I have added a test function to compare your ValidMoves function against the Perft Results obtained from https://www.chessprogramming.org/Perft_Results.

```bash
> go test
--- FAIL: TestPerfResults (0.04s)
    move_test.go:266: rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1
    move_test.go:267:
         A B C D E F G H
        8♜ ♞ ♝ ♛ ♚ ♝ ♞ ♜
        7♟ ♟ ♟ ♟ ♟ ♟ ♟ ♟
        6- - - - - - - -
        5- - - - - - - -
        4- - - - - - - -
        3- - - - - - - -
        2♙ ♙ ♙ ♙ ♙ ♙ ♙ ♙
        1♖ ♘ ♗ ♕ ♔ ♗ ♘ ♖

    move_test.go:268: Depth: 3 Expected: 8902 Got: 8000
    move_test.go:266: r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1
    move_test.go:267:
         A B C D E F G H
        8♜ - - - ♚ - - ♜
        7♟ - ♟ ♟ ♛ ♟ ♝ -
        6♝ ♞ - - ♟ ♞ ♟ -
        5- - - ♙ ♘ - - -
        4- ♟ - - ♙ - - -
        3- - ♘ - - ♕ - ♟
        2♙ ♙ ♙ ♗ ♗ ♙ ♙ ♙
        1♖ - - - ♔ - - ♖

    move_test.go:268: Depth: 2 Expected: 2039 Got: 2304
    move_test.go:266: 8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8 w - - 0 1
    move_test.go:267:
         A B C D E F G H
        8- - - - - - - -
        7- - ♟ - - - - -
        6- - - ♟ - - - -
        5♔ ♙ - - - - - ♜
        4- ♖ - - - ♟ - ♚
        3- - - - - - - -
        2- - - - ♙ - ♙ -
        1- - - - - - - -

    move_test.go:268: Depth: 2 Expected: 191 Got: 196
    move_test.go:266: 8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8 w - - 0 1
    move_test.go:267:
         A B C D E F G H
        8- - - - - - - -
        7- - ♟ - - - - -
        6- - - ♟ - - - -
        5♔ ♙ - - - - - ♜
        4- ♖ - - - ♟ - ♚
        3- - - - - - - -
        2- - - - ♙ - ♙ -
        1- - - - - - - -

    move_test.go:268: Depth: 3 Expected: 2812 Got: 2744
    move_test.go:266: r3k2r/Pppp1ppp/1b3nbN/nP6/BBP1P3/q4N2/Pp1P2PP/R2Q1RK1 w kq - 0 1
    move_test.go:267:
         A B C D E F G H
        8♜ - - - ♚ - - ♜
        7♙ ♟ ♟ ♟ - ♟ ♟ ♟
        6- ♝ - - - ♞ ♝ ♘
        5♞ ♙ - - - - - -
        4♗ ♗ ♙ - ♙ - - -
        3♛ - - - - ♘ - -
        2♙ ♟ - ♙ - - ♙ ♙
        1♖ - - ♕ - ♖ ♔ -

    move_test.go:268: Depth: 2 Expected: 264 Got: 36
    move_test.go:266: r3k2r/Pppp1ppp/1b3nbN/nP6/BBP1P3/q4N2/Pp1P2PP/R2Q1RK1 w kq - 0 1
    move_test.go:267:
         A B C D E F G H
        8♜ - - - ♚ - - ♜
        7♙ ♟ ♟ ♟ - ♟ ♟ ♟
        6- ♝ - - - ♞ ♝ ♘
        5♞ ♙ - - - - - -
        4♗ ♗ ♙ - ♙ - - -
        3♛ - - - - ♘ - -
        2♙ ♟ - ♙ - - ♙ ♙
        1♖ - - ♕ - ♖ ♔ -

    move_test.go:268: Depth: 3 Expected: 9467 Got: 216
    move_test.go:266: r2q1rk1/pP1p2pp/Q4n2/bbp1p3/Np6/1B3NBn/pPPP1PPP/R3K2R b KQ - 0 1
    move_test.go:267:
         A B C D E F G H
        8♜ - - ♛ - ♜ ♚ -
        7♟ ♙ - ♟ - - ♟ ♟
        6♕ - - - - ♞ - -
        5♝ ♝ ♟ - ♟ - - -
        4♘ ♟ - - - - - -
        3- ♗ - - - ♘ ♗ ♞
        2♟ ♙ ♙ ♙ - ♙ ♙ ♙
        1♖ - - - ♔ - - ♖

    move_test.go:268: Depth: 2 Expected: 264 Got: 36
    move_test.go:266: r2q1rk1/pP1p2pp/Q4n2/bbp1p3/Np6/1B3NBn/pPPP1PPP/R3K2R b KQ - 0 1
    move_test.go:267:
         A B C D E F G H
        8♜ - - ♛ - ♜ ♚ -
        7♟ ♙ - ♟ - - ♟ ♟
        6♕ - - - - ♞ - -
        5♝ ♝ ♟ - ♟ - - -
        4♘ ♟ - - - - - -
        3- ♗ - - - ♘ ♗ ♞
        2♟ ♙ ♙ ♙ - ♙ ♙ ♙
        1♖ - - - ♔ - - ♖

    move_test.go:268: Depth: 3 Expected: 9467 Got: 216
    move_test.go:266: rnbq1k1r/pp1Pbppp/2p5/8/2B5/8/PPP1NnPP/RNBQK2R w KQ - 1 8
    move_test.go:267:
         A B C D E F G H
        8♜ ♞ ♝ ♛ - ♚ - ♜
        7♟ ♟ - ♙ ♝ ♟ ♟ ♟
        6- - ♟ - - - - -
        5- - - - - - - -
        4- - ♗ - - - - -
        3- - - - - - - -
        2♙ ♙ ♙ - ♘ ♞ ♙ ♙
        1♖ ♘ ♗ ♕ ♔ - - ♖

    move_test.go:268: Depth: 2 Expected: 1486 Got: 1936
    move_test.go:266: r4rk1/1pp1qppp/p1np1n2/2b1p1B1/2B1P1b1/P1NP1N2/1PP1QPPP/R4RK1 w - - 0 10
    move_test.go:267:
         A B C D E F G H
        8♜ - - - - ♜ ♚ -
        7- ♟ ♟ - ♛ ♟ ♟ ♟
        6♟ - ♞ ♟ - ♞ - -
        5- - ♝ - ♟ - ♗ -
        4- - ♗ - ♙ - ♝ -
        3♙ - ♘ ♙ - ♘ - -
        2- ♙ ♙ - ♕ ♙ ♙ ♙
        1♖ - - - - ♖ ♔ -

    move_test.go:268: Depth: 2 Expected: 2079 Got: 2116
FAIL
exit status 1
FAIL	github.com/Kerrigan29a/chess	0.285s
```