### PR TITLE
Added basic cache mechanism and parallelization to perf tests

### DIFF
--- a/move_test.go
+++ b/move_test.go
@@ -243,9 +243,7 @@ var perfResults = []perfTest{
 }
 
 // func TestPerfResults(t *testing.T) {
-// 	//cache := make(map[[16]byte][]*Position, 0)
 // 	for _, perf := range perfResults {
-// 		//countMoves(t, perf.pos, []*Position{perf.pos}, perf.nodesPerDepth, len(perf.nodesPerDepth), cache)
 // 		countMoves(t, perf.pos, []*Position{perf.pos}, perf.nodesPerDepth, len(perf.nodesPerDepth), make(map[[16]byte][]*Position, 0))
 // 	}
 // }


### PR DESCRIPTION
I have added 3 different `TestPerfResults` versions:
1. With shared cache
2. With one cache for each problem
3. With one cache for each problem running each program in parallel

I don't know why the quickest one for me is  the second one but it's possible that the third one runs quicker in a PC with more cores than my laptop. 

Test them and make some suggestions