### PR TITLE
Added Pawn case to select for String method on PieceType

### DIFF
--- a/piece.go
+++ b/piece.go
@@ -83,6 +83,8 @@ func (p PieceType) String() string {
 		return "b"
 	case Knight:
 		return "n"
+	case Pawn:
+		return "p"
 	}
 	return ""
 }

--- a/piece_test.go
+++ b/piece_test.go
@@ -1,0 +1,23 @@
+package chess
+
+import "testing"
+
+func TestPieceString(t *testing.T) {
+	tables := []struct {
+		piece PieceType
+		str   string
+	}{
+		{King, "k"},
+		{Queen, "q"},
+		{Rook, "r"},
+		{Bishop, "b"},
+		{Knight, "n"},
+		{Pawn, "p"},
+	}
+
+	for _, table := range tables {
+		if table.piece.String() != table.str {
+			t.Errorf("String version of piece was incorrect.")
+		}
+	}
+}


### PR DESCRIPTION
Not returning "p" for pawn may have been intentional and could be determined by only the color of the piece. However, I thought it best to return the string version of the PieceType for consistency.

I also wrote a test for my changes.

Closes #34 
