### PR TITLE
Return useful panic message

### DIFF
--- a/board.go
+++ b/board.go
@@ -370,6 +370,6 @@ func (b *Board) setBBForPiece(p Piece, bb bitboard) {
 	case BlackPawn:
 		b.bbBlackPawn = bb
 	default:
-		panic("HERE")
+		panic("invalid piece")
 	}
 }


### PR DESCRIPTION
Currently the panic message does not return any helpful message to hint where the problem is. A more helpful message can ease debugging.