### PR TITLE
remove line breaks first to enable support for PGNs with annotations with line breaks

### DIFF
--- a/pgn.go
+++ b/pgn.go
@@ -195,14 +195,14 @@ var (
 )
 
 func moveList(pgn string) ([]string, Outcome) {
+	// remove line breaks
+	text := strings.Replace(pgn, "\n", " ", -1)
 	// remove comments
-	text := removeSection("{", "}", pgn)
+	text = removeSection("{", "}", text)
 	// remove variations
 	text = removeSection(`\(`, `\)`, text)
 	// remove tag pairs
 	text = removeSection(`\[`, `\]`, text)
-	// remove line breaks
-	text = strings.Replace(text, "\n", " ", -1)
 
 	list := strings.Split(text, " ")
 	filtered := []string{}

--- a/pgn_test.go
+++ b/pgn_test.go
@@ -23,7 +23,8 @@ var (
             [Result "1-0"]
             [WhiteElo "2795"]
 
-            1. Nf3 d5 2. g3 Bg4 3. b3 Nd7 4. Bb2 e6 5. Bg2 Ngf6 6. O-O c6
+			1. Nf3 d5 2. g3 Bg4 3. b3 Nd7 4. Bb2 e6 5. Bg2 Ngf6 6. O-O c6 {[%clk 0:02:56.4][%timestamp
+				24]}
             7. d3 Bd6 8. Nbd2 O-O 9. h3 Bh5 10. e3 h6 11. Qe1 Qa5 12. a3
             Bc7 13. Nh4 g5 14. Nhf3 e5 15. e4 Rfe8 16. Nh2 Qb6 17. Qc1 a5
             18. Re1 Bd6 19. Ndf1 dxe4 20. dxe4 Bc5 21. Ne3 Rad8 22. Nhf1 g4


### PR DESCRIPTION
I was testing my own PGN database and ran into many cases where the PGN annotations had line breaks in them. This caused the parsing to fail. By moving the line break removal to the first step of this method, it seems to have not broken any existing tests and also adds support for the maybe malformed PGN database I have.

My PGN database is a download of the games I have played from a popular online community :). (about 3k games).

I can add an example PGN from my dataset as a test if that would help.