### PR TITLE
pgn.encodePGN: add space between move number period and white's move

### DIFF
--- a/game_test.go
+++ b/game_test.go
@@ -216,6 +216,8 @@ func TestSufficentMaterial(t *testing.T) {
 
 func TestSerializationCycle(t *testing.T) {
 	g := NewGame()
+	g.MoveStr("e4")
+	g.MoveStr("e5")
 	pgn, err := PGN(strings.NewReader(g.String()))
 	if err != nil {
 		t.Fatal(err)

--- a/pgn.go
+++ b/pgn.go
@@ -191,7 +191,7 @@ func encodePGN(g *Game) string {
 		pos := g.positions[i]
 		txt := g.notation.Encode(pos, move)
 		if i%2 == 0 {
-			s += fmt.Sprintf("%d.%s", (i/2)+1, txt)
+			s += fmt.Sprintf("%d. %s", (i/2)+1, txt)
 		} else {
 			s += fmt.Sprintf(" %s ", txt)
 		}


### PR DESCRIPTION
Also updated the test to ensure that the encode/decode cycle works correctly. (Before, it was just parsing an empty string which always works.)