### PR TITLE
Remove castling rights change check for half move increment

### DIFF
--- a/fixtures/valid_notation_tests.json
+++ b/fixtures/valid_notation_tests.json
@@ -17,7 +17,7 @@
 	},
 	{
 		"pos1" : "r2qk2r/pp1n1ppp/2pbpn2/3p4/2PP4/1PNQPN2/P4PPP/R1B1K2R w KQkq - 1 9",
-		"pos2" : "r2qk2r/pp1n1ppp/2pbpn2/3p4/2PP4/1PNQPN2/P4PPP/R1B2RK1 b kq - 0 9",
+		"pos2" : "r2qk2r/pp1n1ppp/2pbpn2/3p4/2PP4/1PNQPN2/P4PPP/R1B2RK1 b kq - 2 9",
 		"algText" : "O-O",
 		"longAlgText" : "O-O",
 		"uciText" : "e1g1",
@@ -73,7 +73,7 @@
 	},
 	{
 		"pos1" : "rnbk1b1r/p3pppp/5n2/2p1p3/5B2/2N2P2/PPP3PP/R3KBNR w KQ - 0 10",
-		"pos2" : "rnbk1b1r/p3pppp/5n2/2p1p3/5B2/2N2P2/PPP3PP/2KR1BNR b - - 0 10",
+		"pos2" : "rnbk1b1r/p3pppp/5n2/2p1p3/5B2/2N2P2/PPP3PP/2KR1BNR b - - 1 10",
 		"algText" : "O-O-O+",
 		"longAlgText" : "O-O-O+",
 		"uciText" : "e1c1",

--- a/move_test.go
+++ b/move_test.go
@@ -133,7 +133,7 @@ var (
 		{
 			m:       &Move{s1: E1, s2: G1, tags: KingSideCastle},
 			pos:     unsafeFEN("r3k2r/8/8/8/8/8/8/R3K2R w KQkq - 0 1"),
-			postPos: unsafeFEN("r3k2r/8/8/8/8/8/8/R4RK1 b kq - 0 1"),
+			postPos: unsafeFEN("r3k2r/8/8/8/8/8/8/R4RK1 b kq - 1 1"),
 		},
 		{
 			m:       &Move{s1: A4, s2: B3, tags: EnPassant},
@@ -143,7 +143,7 @@ var (
 		{
 			m:       &Move{s1: E1, s2: G1, tags: KingSideCastle},
 			pos:     unsafeFEN("r2qk2r/pp1n1ppp/2pbpn2/3p4/2PP4/1PNQPN2/P4PPP/R1B1K2R w KQkq - 1 9"),
-			postPos: unsafeFEN("r2qk2r/pp1n1ppp/2pbpn2/3p4/2PP4/1PNQPN2/P4PPP/R1B2RK1 b kq - 0 9"),
+			postPos: unsafeFEN("r2qk2r/pp1n1ppp/2pbpn2/3p4/2PP4/1PNQPN2/P4PPP/R1B2RK1 b kq - 2 9"),
 		},
 	}
 )

--- a/move_test.go
+++ b/move_test.go
@@ -1,6 +1,7 @@
 package chess
 
 import (
+	"fmt"
 	"log"
 	"testing"
 )
@@ -146,6 +147,54 @@ var (
 			postPos: unsafeFEN("r2qk2r/pp1n1ppp/2pbpn2/3p4/2PP4/1PNQPN2/P4PPP/R1B2RK1 b kq - 2 9"),
 		},
 	}
+
+	validHalfMoveClockIncrements = []moveTest{
+		// knight move to f3 from starting position
+		{
+			m:       &Move{s1: G1, s2: F3},
+			pos:     unsafeFEN("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"),
+			postPos: unsafeFEN("rnbqkbnr/pppppppp/8/8/8/5N2/PPPPPPPP/RNBQKB1R b KQkq - 1 1"),
+		},
+		// king side castle
+		{
+			m:       &Move{s1: E1, s2: G1, tags: KingSideCastle},
+			pos:     unsafeFEN("r3k2r/8/8/8/8/8/8/R3K2R w KQkq - 0 1"),
+			postPos: unsafeFEN("r3k2r/8/8/8/8/8/8/R4RK1 b kq - 1 1"),
+		},
+		// queen side castle
+		{
+			m:       &Move{s1: E1, s2: C1, tags: QueenSideCastle},
+			pos:     unsafeFEN("r3k2r/ppqn1ppp/2pbpn2/3p4/2PP4/1PNQPN2/P2B1PPP/R3K2R w KQkq - 3 10"),
+			postPos: unsafeFEN("r3k2r/ppqn1ppp/2pbpn2/3p4/2PP4/1PNQPN2/P2B1PPP/2KR3R b kq - 4 10"),
+		},
+	}
+
+	invalidHalfMoveClockIncrements = []moveTest{
+		// pawn push
+		{
+			m:       &Move{s1: E2, s2: E4},
+			pos:     unsafeFEN("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"),
+			postPos: unsafeFEN("rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 1 1"),
+		},
+		// pawn capture
+		{
+			m:       &Move{s1: E4, s2: D5, tags: Capture},
+			pos:     unsafeFEN("r1bqkbnr/ppp1pppp/2n5/3p4/4P3/5N2/PPPP1PPP/RNBQKB1R w KQkq - 2 3"),
+			postPos: unsafeFEN("r1bqkbnr/ppp1pppp/2n5/3P4/8/5N2/PPPP1PPP/RNBQKB1R b KQkq - 3 3"),
+		},
+		// en passant
+		{
+			m:       &Move{s1: E5, s2: F6, tags: EnPassant},
+			pos:     unsafeFEN("r1bqkbnr/ppp1p1pp/2n5/3pPp2/8/5N2/PPPP1PPP/RNBQKB1R w KQkq f6 0 4"),
+			postPos: unsafeFEN("r1bqkbnr/ppp1p1pp/2n2P2/3p4/8/5N2/PPPP1PPP/RNBQKB1R b KQkq - 1 4"),
+		},
+		// piece captured by knight
+		{
+			m:       &Move{s1: C6, s2: D4, tags: Capture},
+			pos:     unsafeFEN("r1bqkbnr/ppp1p1pp/2n5/3pPp2/3N4/8/PPPP1PPP/RNBQKB1R b KQkq - 1 4"),
+			postPos: unsafeFEN("r1bqkbnr/ppp1p1pp/8/3pPp2/3n4/8/PPPP1PPP/RNBQKB1R w KQkq - 2 5"),
+		},
+	}
 )
 
 func unsafeFEN(s string) *Position {
@@ -199,6 +248,49 @@ func TestPositionUpdates(t *testing.T) {
 				mt.postPos.board.Draw(),
 				postPos.String(),
 				postPos.board.Draw(),
+			)
+		}
+	}
+}
+
+func TestValidHalfMoveClockIncrements(t *testing.T) {
+	for _, mt := range validHalfMoveClockIncrements {
+		if !moveIsValid(mt.pos, mt.m, true) {
+			log.Println(mt.pos.String())
+			log.Println(mt.pos.board.Draw())
+			log.Println(mt.pos.ValidMoves())
+			t.Fatalf("expected move %s %v to be valid", mt.m, mt.m.tags)
+		}
+
+		postPos := mt.pos.Update(mt.m)
+		if postPos.halfMoveClock != mt.postPos.halfMoveClock {
+			t.Fatalf("\nstarting from fen %s\n with half move clock at %s\n after move %s\n expected half move clock to be %s\n but was %s\n",
+				mt.pos.String(),
+				fmt.Sprint(mt.pos.halfMoveClock),
+				mt.m.String(),
+				fmt.Sprint(mt.postPos.halfMoveClock),
+				fmt.Sprint(postPos.halfMoveClock),
+			)
+		}
+	}
+}
+
+func TestInvalidHalfMoveClockIncrements(t *testing.T) {
+	for _, mt := range invalidHalfMoveClockIncrements {
+		if !moveIsValid(mt.pos, mt.m, true) {
+			log.Println(mt.pos.String())
+			log.Println(mt.pos.board.Draw())
+			log.Println(mt.pos.ValidMoves())
+			t.Fatalf("expected move %s %v to be valid", mt.m, mt.m.tags)
+		}
+
+		postPos := mt.pos.Update(mt.m)
+		if postPos.halfMoveClock == mt.postPos.halfMoveClock {
+			t.Fatalf("\nstarting from fen %s\n with half move clock at %s\n after move %s\n expected half move clock to be 0\n but was %s\n",
+				mt.pos.String(),
+				fmt.Sprint(mt.pos.halfMoveClock),
+				mt.m.String(),
+				fmt.Sprint(postPos.halfMoveClock),
 			)
 		}
 	}

--- a/notation_test.go
+++ b/notation_test.go
@@ -51,7 +51,8 @@ func TestValidDecoding(t *testing.T) {
 			}
 			postPos := test.Pos1.Update(m)
 			if test.Pos2.String() != postPos.String() {
-				t.Fatalf("starting from board \n%s\n after move %s\n expected board to be %s\n%s\n but was %s\n%s\n",
+				t.Fatalf("starting from board \n%s%s\n after move %s\n expected board to be %s\n%s\n but was %s\n%s\n",
+					test.Pos1.String(),
 					test.Pos1.board.Draw(), m.String(), test.Pos2.String(),
 					test.Pos2.board.Draw(), postPos.String(), postPos.board.Draw())
 			}
@@ -86,7 +87,7 @@ var (
 			N:       AlgebraicNotation{},
 			Pos:     unsafeFEN("r2qk2r/pp1n1ppp/2pbpn2/3p4/2PP4/1PNQPN2/P4PPP/R1B1K2R w KQkq - 1 9"),
 			Text:    "O-O-O-O",
-			PostPos: unsafeFEN("r2qk2r/pp1n1ppp/2pbpn2/3p4/2PP4/1PNQPN2/P4PPP/R1B2RK1 b kq - 0 9"),
+			PostPos: unsafeFEN("r2qk2r/pp1n1ppp/2pbpn2/3p4/2PP4/1PNQPN2/P4PPP/R1B2RK1 b kq - 2 9"),
 		},
 		{
 			// http://en.lichess.org/W91M4jms#23

--- a/position.go
+++ b/position.go
@@ -74,11 +74,10 @@ func (pos *Position) Update(m *Move) *Position {
 	if pos.turn == Black {
 		moveCount++
 	}
-	cr := pos.CastleRights()
 	ncr := pos.updateCastleRights(m)
 	p := pos.board.Piece(m.s1)
 	halfMove := pos.halfMoveClock
-	if p.Type() == Pawn || m.HasTag(Capture) || cr != ncr {
+	if p.Type() == Pawn || m.HasTag(Capture) {
 		halfMove = 0
 	} else {
 		halfMove++


### PR DESCRIPTION
**Current behaviour**
When checking if the half move clock should be incremented: If there is a change in castling rights then the half move clock is set back to 0.

**Expected behaviour**
According to several sources, half move clock should not be set to 0 when castling rights change but incremented.
- [Chess programming half move clock](https://www.chessprogramming.org/Halfmove_Clock)
- [Chess programming castling](https://www.chessprogramming.org/Castling)
    - See section on irreversibility (used in detecting repetitions) however does not reset half move clock
- Also tested this out on Lichess and the half move clock is incremented when castling, see this [study](https://lichess.org/study/5oxn7Z2s) I made as an example. (To see FEN, go to share/export tab and scroll down).

Thanks for the awesome library!