### PR TITLE
feat: Expose getPiece as GetPiece

### DIFF
--- a/board.go
+++ b/board.go
@@ -233,7 +233,7 @@ func (b *Board) update(m *Move) {
 	}
 	// check promotion
 	if m.promo != NoPieceType {
-		newPiece := getPiece(m.promo, p1.Color())
+		newPiece := GetPiece(m.promo, p1.Color())
 		// remove pawn
 		bbPawn := b.bbForPiece(p1)
 		b.setBBForPiece(p1, bbPawn & ^s2BB)

--- a/engine.go
+++ b/engine.go
@@ -133,25 +133,25 @@ func squaresAreAttacked(pos *Position, sqs ...Square) bool {
 			continue
 		}
 		// check queen attack vector
-		queenBB := pos.board.bbForPiece(getPiece(Queen, otherColor))
+		queenBB := pos.board.bbForPiece(GetPiece(Queen, otherColor))
 		bb := (diaAttack(occ, sq) | hvAttack(occ, sq)) & queenBB
 		if bb != 0 {
 			return true
 		}
 		// check rook attack vector
-		rookBB := pos.board.bbForPiece(getPiece(Rook, otherColor))
+		rookBB := pos.board.bbForPiece(GetPiece(Rook, otherColor))
 		bb = hvAttack(occ, sq) & rookBB
 		if bb != 0 {
 			return true
 		}
 		// check bishop attack vector
-		bishopBB := pos.board.bbForPiece(getPiece(Bishop, otherColor))
+		bishopBB := pos.board.bbForPiece(GetPiece(Bishop, otherColor))
 		bb = diaAttack(occ, sq) & bishopBB
 		if bb != 0 {
 			return true
 		}
 		// check knight attack vector
-		knightBB := pos.board.bbForPiece(getPiece(Knight, otherColor))
+		knightBB := pos.board.bbForPiece(GetPiece(Knight, otherColor))
 		bb = bbKnightMoves[sq] & knightBB
 		if bb != 0 {
 			return true
@@ -173,7 +173,7 @@ func squaresAreAttacked(pos *Position, sqs ...Square) bool {
 			}
 		}
 		// check king attack vector
-		kingBB := pos.board.bbForPiece(getPiece(King, otherColor))
+		kingBB := pos.board.bbForPiece(GetPiece(King, otherColor))
 		bb = bbKingMoves[sq] & kingBB
 		if bb != 0 {
 			return true

--- a/piece.go
+++ b/piece.go
@@ -128,7 +128,7 @@ var (
 	}
 )
 
-func getPiece(t PieceType, c Color) Piece {
+func GetPiece(t PieceType, c Color) Piece {
 	for _, p := range allPieces {
 		if p.Color() == c && p.Type() == t {
 			return p


### PR DESCRIPTION
Currently, there's no way to build a *chess.Piece from the constituent
PieceType and Color... it's useful, as it exists in the package already,
so it seems nice to make this helper function public.