### PR TITLE
Add support for nil move in Position.Update

### DIFF
--- a/position.go
+++ b/position.go
@@ -74,6 +74,19 @@ func (pos *Position) Update(m *Move) *Position {
 	if pos.turn == Black {
 		moveCount++
 	}
+
+	if m == nil {
+		return &Position{
+			board:           pos.board.copy(),
+			turn:            pos.turn.Other(),
+			castleRights:    pos.castleRights,
+			enPassantSquare: NoSquare,
+			halfMoveClock:   pos.halfMoveClock + 1,
+			moveCount:       moveCount,
+			inCheck:         false,
+		}
+	}
+
 	ncr := pos.updateCastleRights(m)
 	p := pos.board.Piece(m.s1)
 	halfMove := pos.halfMoveClock

--- a/position_test.go
+++ b/position_test.go
@@ -23,3 +23,38 @@ func TestPositionBinary(t *testing.T) {
 		}
 	}
 }
+
+func TestPositionUpdate(t *testing.T) {
+	for _, fen := range validFENs {
+		pos, err := decodeFEN(fen)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		{
+			np := pos.Update(pos.ValidMoves()[0])
+			if pos.Turn().Other() != np.turn {
+				t.Fatal("expected other turn")
+			}
+			if pos.halfMoveClock+1 != np.halfMoveClock {
+				t.Fatal("expected half move clock increment")
+			}
+			if pos.board.String() == np.board.String() {
+				t.Fatal("expected board update")
+			}
+		}
+
+		{
+			np := pos.Update(nil)
+			if pos.Turn().Other() != np.turn {
+				t.Fatal("expected other turn")
+			}
+			if pos.halfMoveClock+1 != np.halfMoveClock {
+				t.Fatal("expected half move clock increment")
+			}
+			if pos.board.String() != np.board.String() {
+				t.Fatal("expected same board")
+			}
+		}
+	}
+}


### PR DESCRIPTION
First, thanks for the awesome library! I'm using it to write a toy chess engine.

Then, this PR:

`Position.Update` is useful for game engines when also using the `ValidMoves` method as it skips redundant validation. It would also be useful to add support for nil move to make it act like passing is a thing in chess.

This could be used in the context of implementing [null move pruning](https://www.chessprogramming.org/Null_Move_Pruning) or in quiescence search to check if not capturing is better than capturing.

Currently, when passed nil `Position.Update` panics. The proposal is that when passed nil, it returns the same position with the opposite turn.