### PR TITLE
Prevent group signals to kill engine processes

### DIFF
--- a/uci/engine.go
+++ b/uci/engine.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"sync"
+	"syscall"
 )
 
 // Engine represents a UCI compliant chess engine (e.g. Stockfish, Shredder, etc.).
@@ -51,6 +52,9 @@ func New(path string, opts ...func(e *Engine)) (*Engine, error) {
 	cmd := exec.Command(path)
 	cmd.Stdin = rIn
 	cmd.Stdout = wOut
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Setpgid: true,
+	}
 	e := &Engine{cmd: cmd, in: wIn, out: rOut, mu: &sync.RWMutex{}, logger: log.New(os.Stdout, "uci", log.LstdFlags)}
 	for _, opt := range opts {
 		opt(e)


### PR DESCRIPTION
The issue happens when implementing cancellation and graceful shutdown for interrupt signals, for example in a CLI when a user presses CTRL+C. We capture the signals and prevent the immediate exit. The expected behavior would be for the parent application to have control over when the engine subprocess ends and eventually kill it with `uci.Engine.Close()` while handling its shutdown.

However, the shell signal the entire process group when pressing CTRL+C. Therefore the engine subprocess is killed immediately and the parent process loses control. If waiting on engine output, it is left hanging.

To prevent the shell from signaling the children, we need to start the command in its own process group. This PR implements this.

If having the engine subprocess in the same process group as the parent is sometimes desirable, then alternatively it would be nice to have an option to control the behavior.