### PR TITLE
Fix PGN parsing of games w/ nested variations

### DIFF
--- a/fixtures/pgns/0013.pgn
+++ b/fixtures/pgns/0013.pgn
@@ -1,0 +1,39 @@
+[Event "Test Nested Variations for https://github.com/notnil/chess: Smith-Morra Accepted; Paulsen Formation"]
+[Site "https://lichess.org/study/lOO87pCX/BZELlaSA"]
+[Result "*"]
+[UTCDate "2023.05.26"]
+[UTCTime "16:09:59"]
+[Variant "Standard"]
+[ECO "B21"]
+[Opening "Sicilian Defense: Smith-Morra Gambit Accepted, Paulsen Formation"]
+[Annotator "https://lichess.org/@/bughouse26"]
+
+1. e4 c5 2. d4 cxd4 3. c3 dxc3 4. Nxc3 Nc6 5. Nf3 e6 6. Bc4 a6 7. O-O b5 { move comment with with braces  ?  } 8. Bb3 *
+
+
+[Event "Test Nested Variations for https://github.com/notnil/chess: Smith-Morra Declined; Alapin Formation"]
+[Site "https://lichess.org/study/lOO87pCX/fC2Vw8Fz"]
+[Result "*"]
+[UTCDate "2023.05.26"]
+[UTCTime "16:13:20"]
+[Variant "Standard"]
+[ECO "B22"]
+[Opening "Sicilian Defense: Alapin Variation, Smith-Morra Declined"]
+[Annotator "https://lichess.org/@/bughouse26"]
+
+1. e4 c5 2. d4 cxd4 3. c3 Nf6 4. e5 Nd5 5. Nf3 Nc6 6. cxd4 d6 { chapter 2 main line move comment with parens ( test ) } 7. Bc4 Nb6 (7... dxe5 { chapter 2 variation move comment with unmatched paren ( } 8. dxe5) 8. Bb5 *
+
+
+[Event "Test Nested Variations for https://github.com/notnil/chess: Smith-Morra Declined; Push Variation"]
+[Site "https://lichess.org/study/lOO87pCX/XaAI645Y"]
+[Result "*"]
+[UTCDate "2023.05.26"]
+[UTCTime "16:16:43"]
+[Variant "Standard"]
+[ECO "B21"]
+[Opening "Sicilian Defense: Smith-Morra Gambit Declined, Push Variation"]
+[Annotator "https://lichess.org/@/bughouse26"]
+
+1. e4 c5 2. d4 cxd4 3. c3 d3 4. Bxd3 Nc6 { chapter 3 main line move comment } 5. Nf3 g6 6. O-O (6. c4 Bg7 { chapter 3 variation 1 comment } 7. O-O) 6... Bg7 7. Qe2 d6 (7... Nf6 8. Rd1 { chapter 3 variation 2 comment } 8... O-O (8... d6 9. e5 dxe5 { chapter 3 nested variation comment } 10. Bxg6 Qc7 { chapter 3 double nested variation comment with parens and moves ( 1. e4 e5 2. Nf3 ) } (10... Qxd1+ 11. Qxd1) 11. Bc2) 9. e5) 8. Rd1 Qc7 9. Na3 a6 10. Bf4 Nf6 11. e5 dxe5 (11... Nh5 12. exd6)  (11... Nd5 12. exd6) *
+
+

--- a/pgn_test.go
+++ b/pgn_test.go
@@ -1,6 +1,8 @@
 package chess
 
 import (
+	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
 	"strings"
@@ -151,6 +153,40 @@ func TestScanner(t *testing.T) {
 		if len(games) != 5 {
 			t.Fatalf(fname+" expected 5 games but got %d", len(games))
 		}
+	}
+}
+
+func TestScannerWithNested(t *testing.T) {
+	fname := "fixtures/pgns/0013.pgn"
+	f, err := os.Open(fname)
+	if err != nil {
+		panic(err)
+	}
+	defer f.Close()
+
+	scanner := NewScanner(f)
+	games := []*Game{}
+	for scanner.Scan() {
+		err = scanner.Err()
+		if err != nil && err != io.EOF {
+			t.Fatalf(fname+" Unexpected non-nil/non-EOF err %v", err)
+		}
+		game := scanner.Next()
+		moveList := game.Moves()
+		if len(moveList) == 0 {
+			continue
+		}
+		games = append(games, game)
+	}
+	err = scanner.Err()
+	if err != io.EOF {
+		t.Fatalf(fname+" Unexpected non-EOF err %v", err)
+	}
+	if len(games) != 3 {
+		for idx, g := range games {
+			fmt.Printf("Parsed game %v: %v\n\n", idx, g)
+		}
+		t.Fatalf(fname+" expected 3 games but got %d", len(games))
 	}
 }
 

--- a/pgn_test.go
+++ b/pgn_test.go
@@ -1,8 +1,6 @@
 package chess
 
 import (
-	"fmt"
-	"io"
 	"io/ioutil"
 	"os"
 	"strings"
@@ -138,11 +136,11 @@ func TestWriteComments(t *testing.T) {
 }
 
 func TestScanner(t *testing.T) {
-  m := map[string]int{
-    "fixtures/pgns/0006.pgn":5,
-    "fixtures/pgns/0007.pgn":5,
-    "fixtures/pgns/0013.pgn":3,
-  }
+	m := map[string]int{
+		"fixtures/pgns/0006.pgn": 5,
+		"fixtures/pgns/0007.pgn": 5,
+		"fixtures/pgns/0013.pgn": 3,
+	}
 	for fname, count := range m {
 		f, err := os.Open(fname)
 		if err != nil {
@@ -153,6 +151,9 @@ func TestScanner(t *testing.T) {
 		games := []*Game{}
 		for scanner.Scan() {
 			game := scanner.Next()
+			if len(game.Moves()) == 0 {
+				continue
+			}
 			games = append(games, game)
 		}
 		if len(games) != count {


### PR DESCRIPTION
Existing moveListWithComments() contains a parsing bug when the pgn in question contains a game with nested variations. In this case the moveListTokenRe regex doesn't work as expected and results in attempts to parse an illegal game. To demonstrate the problem this commit adds a TestScannerWithNested() test case along with a 0013.pgn fixture which is an export of a lichess study. This commit also fixes the problem by adding a stripVariations() preprocess step in moveListWithComments(). I have a subsequent commit coming which adds a Scanner option to include variations in the game list when processing a pgn.