### PR TITLE
Scanner: Add option flag to expand variations

### DIFF
--- a/fixtures/pgns/0013.pgn
+++ b/fixtures/pgns/0013.pgn
@@ -1,0 +1,39 @@
+[Event "Test Nested Variations for https://github.com/notnil/chess: Smith-Morra Accepted; Paulsen Formation"]
+[Site "https://lichess.org/study/lOO87pCX/BZELlaSA"]
+[Result "*"]
+[UTCDate "2023.05.26"]
+[UTCTime "16:09:59"]
+[Variant "Standard"]
+[ECO "B21"]
+[Opening "Sicilian Defense: Smith-Morra Gambit Accepted, Paulsen Formation"]
+[Annotator "https://lichess.org/@/bughouse26"]
+
+1. e4 c5 2. d4 cxd4 3. c3 dxc3 4. Nxc3 Nc6 5. Nf3 e6 6. Bc4 a6 7. O-O b5 { move comment with with braces  ?  } 8. Bb3 *
+
+
+[Event "Test Nested Variations for https://github.com/notnil/chess: Smith-Morra Declined; Alapin Formation"]
+[Site "https://lichess.org/study/lOO87pCX/fC2Vw8Fz"]
+[Result "*"]
+[UTCDate "2023.05.26"]
+[UTCTime "16:13:20"]
+[Variant "Standard"]
+[ECO "B22"]
+[Opening "Sicilian Defense: Alapin Variation, Smith-Morra Declined"]
+[Annotator "https://lichess.org/@/bughouse26"]
+
+1. e4 c5 2. d4 cxd4 3. c3 Nf6 4. e5 Nd5 5. Nf3 Nc6 6. cxd4 d6 { chapter 2 main line move comment with parens ( test ) } 7. Bc4 Nb6 (7... dxe5 { chapter 2 variation move comment with unmatched paren ( } 8. dxe5) 8. Bb5 *
+
+
+[Event "Test Nested Variations for https://github.com/notnil/chess: Smith-Morra Declined; Push Variation"]
+[Site "https://lichess.org/study/lOO87pCX/XaAI645Y"]
+[Result "*"]
+[UTCDate "2023.05.26"]
+[UTCTime "16:16:43"]
+[Variant "Standard"]
+[ECO "B21"]
+[Opening "Sicilian Defense: Smith-Morra Gambit Declined, Push Variation"]
+[Annotator "https://lichess.org/@/bughouse26"]
+
+1. e4 c5 2. d4 cxd4 3. c3 d3 4. Bxd3 Nc6 { chapter 3 main line move comment } 5. Nf3 g6 6. O-O (6. c4 Bg7 { chapter 3 variation 1 comment } 7. O-O) 6... Bg7 7. Qe2 d6 (7... Nf6 8. Rd1 { chapter 3 variation 2 comment } 8... O-O (8... d6 9. e5 dxe5 { chapter 3 nested variation comment } 10. Bxg6 Qc7 { chapter 3 double nested variation comment with parens and moves ( 1. e4 e5 2. Nf3 ) } (10... Qxd1+ 11. Qxd1) 11. Bc2) 9. e5) 8. Rd1 Qc7 9. Na3 a6 10. Bf4 Nf6 11. e5 dxe5 (11... Nh5 12. exd6)  (11... Nd5 12. exd6) *
+
+

--- a/pgn.go
+++ b/pgn.go
@@ -299,7 +299,7 @@ func moveListSetWithComments(pgn string, expandVariations bool) (moveListSet, er
 		return ret, nil
 	}
 
-	return ret, fmt.Errorf("unimplemented")
+	return moveListSetExpanded(pgn)
 }
 
 func moveListWithCommentsNoExpand(pgn string) (moveListAndOutcome, error) {
@@ -332,6 +332,66 @@ func moveListWithCommentsNoExpand(pgn string) (moveListAndOutcome, error) {
 			ret.moves = append(ret.moves, moveWithComment{MoveStr: move})
 		}
 	}
+	return ret, nil
+}
+
+var moveNumRe = regexp.MustCompile(`(?:\d+\.+)?(.*)`)
+
+func moveListSetExpanded(pgn string) (moveListSet, error) {
+	firstGame := moveListAndOutcome{
+		moves: []moveWithComment{},
+	}
+	ret := moveListSet{
+		moveLists: []moveListAndOutcome{firstGame},
+	}
+
+	pgn = stripTagPairs(pgn)
+	// remove comments @todo need to add comments back in
+	pgn = removeSection("{", "}", pgn)
+	// remove line breaks
+	pgn = strings.Replace(pgn, "\n", " ", -1)
+	pgn = strings.ReplaceAll(pgn, "(", "( ")
+	pgn = strings.ReplaceAll(pgn, ")", " )")
+
+	moveListIdx := 0
+	moveListIdxStack := make([]int, 0)
+	list := strings.Split(pgn, " ")
+
+	for _, move := range list {
+		move = strings.TrimSpace(move)
+		switch move {
+		case string(NoOutcome), string(WhiteWon), string(BlackWon), string(Draw):
+			ret.moveLists[moveListIdx].outcome = Outcome(move)
+		case "":
+		case "(":
+			// begin new variation
+			moveListIdxStack = append(moveListIdxStack, moveListIdx)
+			newIdx := len(ret.moveLists)
+			numMoves := len(ret.moveLists[moveListIdx].moves) - 1
+			newGame := moveListAndOutcome{}
+			newGame.moves = make([]moveWithComment, numMoves)
+			copy(newGame.moves, ret.moveLists[moveListIdx].moves)
+			ret.moveLists = append(ret.moveLists, newGame)
+			moveListIdx = newIdx
+
+		case ")":
+			// end current variation
+			stackSize := len(moveListIdxStack)
+			if stackSize == 0 {
+				return ret, fmt.Errorf("Failed to parse variation")
+			}
+			moveListIdx = moveListIdxStack[stackSize-1]
+			moveListIdxStack = moveListIdxStack[:stackSize-1]
+		default:
+			results := moveNumRe.FindStringSubmatch(move)
+			tmp := moveWithComment{}
+			if len(results) == 2 && results[1] != "" {
+				tmp.MoveStr = results[1]
+				ret.moveLists[moveListIdx].moves = append(ret.moveLists[moveListIdx].moves, tmp)
+			}
+		}
+	}
+
 	return ret, nil
 }
 
@@ -385,4 +445,15 @@ func stripVariations(pgn string) (string, error) {
 	}
 
 	return ret.String(), nil
+}
+
+func removeSection(leftChar, rightChar, s string) string {
+	r := regexp.MustCompile(leftChar + ".*?" + rightChar)
+	for {
+		i := r.FindStringIndex(s)
+		if i == nil {
+			return s
+		}
+		s = s[0:i[0]] + s[i[1]:]
+	}
 }

--- a/pgn.go
+++ b/pgn.go
@@ -13,16 +13,28 @@ import (
 // from concatenated PGN files.  It is designed to
 // replace GamesFromPGN in order to handle very large
 // PGN database files such as https://database.lichess.org/.
+type ScannerOpts struct {
+	ExpandVariations bool
+}
 type Scanner struct {
 	scanr *bufio.Scanner
-	game  *Game
+	games []*Game
 	err   error
+	opts  ScannerOpts
 }
 
-// NewScanner returns a new scanner.
+// NewScanner returns a new scanner with default options
 func NewScanner(r io.Reader) *Scanner {
+	defaultOpts := ScannerOpts{ExpandVariations: false}
+
+	return NewScannerWithOptions(r, defaultOpts)
+}
+
+// NewScanner returns a new scanner with explicit options
+func NewScannerWithOptions(r io.Reader, o ScannerOpts) *Scanner {
 	scanr := bufio.NewScanner(r)
-	return &Scanner{scanr: scanr}
+	g := make([]*Game, 0)
+	return &Scanner{scanr: scanr, opts: o, games: g}
 }
 
 type scanState int
@@ -41,15 +53,18 @@ func (s *Scanner) Scan() bool {
 		return false
 	}
 	s.err = nil
+	if len(s.games) > 0 {
+		return true
+	}
 	var sb strings.Builder
 	state := notInPGN
-	setGame := func() bool {
-		game, err := decodePGN(sb.String())
+	setGames := func() bool {
+		games, err := decodePGNs(sb.String(), s.opts.ExpandVariations)
 		if err != nil {
 			s.err = err
 			return false
 		}
-		s.game = game
+		s.games = games
 		return true
 	}
 	for {
@@ -60,7 +75,7 @@ func (s *Scanner) Scan() bool {
 			if s.err == nil {
 				s.err = io.EOF
 			}
-			return setGame()
+			return setGames()
 		}
 		line := strings.TrimSpace(s.scanr.Text())
 		isTagPair := strings.HasPrefix(line, "[")
@@ -79,7 +94,7 @@ func (s *Scanner) Scan() bool {
 			sb.WriteString(line + "\n")
 		case inMoves:
 			if line == "" {
-				return setGame()
+				return setGames()
 			}
 			sb.WriteString(line + "\n")
 		}
@@ -88,7 +103,14 @@ func (s *Scanner) Scan() bool {
 
 // Next returns the game from the most recent Scan.
 func (s *Scanner) Next() *Game {
-	return s.game
+	if len(s.games) == 0 {
+		return nil
+	}
+
+	g := s.games[0]
+	s.games = s.games[1:]
+
+	return g
 }
 
 // Err returns an error encountered during scanning.
@@ -149,8 +171,21 @@ func (a multiDecoder) Decode(pos *Position, s string) (*Move, error) {
 }
 
 func decodePGN(pgn string) (*Game, error) {
+	gameList, err := decodePGNs(pgn, false)
+	if err != nil {
+		return nil, err
+	}
+	if len(gameList) != 1 {
+		return nil, fmt.Errorf("chess: pgn decode error unexpected game count %v", len(gameList))
+	}
+
+	return gameList[0], nil
+}
+
+func decodePGNs(pgn string, expandVariations bool) ([]*Game, error) {
+	ret := []*Game{}
 	tagPairs := getTagPairs(pgn)
-	moveComments, outcome, err := moveListWithComments(pgn)
+	moveListSet, err := moveListSetWithComments(pgn, expandVariations)
 	if err != nil {
 		return nil, err
 	}
@@ -167,22 +202,27 @@ func decodePGN(pgn string) (*Game, error) {
 		}
 	}
 	gameFuncs = append(gameFuncs, TagPairs(tagPairs))
-	g := NewGame(gameFuncs...)
-	g.ignoreAutomaticDraws = true
-	decoder := multiDecoder([]Decoder{AlgebraicNotation{}, LongAlgebraicNotation{}, UCINotation{}})
-	for _, move := range moveComments {
-		m, err := decoder.Decode(g.Position(), move.MoveStr)
-		if err != nil {
-			return nil, fmt.Errorf("chess: pgn decode error %s on move %d", err.Error(), g.Position().moveCount)
-		}
-		if err := g.Move(m); err != nil {
-			return nil, fmt.Errorf("chess: pgn invalid move error %s on move %d", err.Error(), g.Position().moveCount)
-		}
-		g.comments = append(g.comments, move.Comments)
-	}
-	g.outcome = outcome
 
-	return g, nil
+	for idx, ml := range moveListSet.moveLists {
+		g := NewGame(gameFuncs...)
+		g.ignoreAutomaticDraws = true
+		decoder := multiDecoder([]Decoder{AlgebraicNotation{}, LongAlgebraicNotation{}, UCINotation{}})
+		for _, move := range ml.moves {
+			m, err := decoder.Decode(g.Position(), move.MoveStr)
+			if err != nil {
+				return nil, fmt.Errorf("chess: pgn decode error %s on variation	%d move %d", err.Error(), idx, g.Position().moveCount)
+			}
+			if err := g.Move(m); err != nil {
+				return nil, fmt.Errorf("chess: pgn invalid move error %s on	variation %d move %d", err.Error(), idx, g.Position().moveCount)
+			}
+			g.comments = append(g.comments, move.Comments)
+		}
+		g.outcome = ml.outcome
+
+		ret = append(ret, g)
+	}
+
+	return ret, nil
 }
 
 func encodePGN(g *Game) string {
@@ -234,16 +274,43 @@ type moveWithComment struct {
 	Comments []string
 }
 
+type moveListAndOutcome struct {
+	moves   []moveWithComment
+	outcome Outcome
+}
+
+type moveListSet struct {
+	moveLists []moveListAndOutcome
+}
+
 var moveListTokenRe = regexp.MustCompile(`(?:\d+\.)|(O-O(?:-O)?|\w*[abcdefgh][12345678]\w*(?:=[QRBN])?(?:\+|#)?)|(?:\{([^}]*)\})|(?:\([^)]*\))|(\*|0-1|1-0|1\/2-1\/2)`)
 
-func moveListWithComments(pgn string) ([]moveWithComment, Outcome, error) {
+func moveListSetWithComments(pgn string, expandVariations bool) (moveListSet, error) {
+	ret := moveListSet{
+		moveLists: []moveListAndOutcome{},
+	}
+
+	if !expandVariations {
+		ml, err := moveListWithCommentsNoExpand(pgn)
+		if err != nil {
+			return ret, err
+		}
+		ret.moveLists = append(ret.moveLists, ml)
+		return ret, nil
+	}
+
+	return ret, fmt.Errorf("unimplemented")
+}
+
+func moveListWithCommentsNoExpand(pgn string) (moveListAndOutcome, error) {
 	pgn = stripTagPairs(pgn)
-	var outcome Outcome
-	moves := []moveWithComment{}
+	ret := moveListAndOutcome{
+		moves: []moveWithComment{},
+	}
 	// moveListTokenRe doesn't work w/ nested variations
 	pgn, err := stripVariations(pgn)
 	if err != nil {
-		return moves, outcome, err
+		return ret, err
 	}
 
 	for _, match := range moveListTokenRe.FindAllStringSubmatch(pgn, -1) {
@@ -253,19 +320,19 @@ func moveListWithComments(pgn string) ([]moveWithComment, Outcome, error) {
 		}
 
 		if outcomeText != "" {
-			outcome = Outcome(outcomeText)
+			ret.outcome = Outcome(outcomeText)
 			break
 		}
 
 		if commentText != "" {
-			moves[len(moves)-1].Comments = append(moves[len(moves)-1].Comments, strings.TrimSpace(commentText))
+			ret.moves[len(ret.moves)-1].Comments = append(ret.moves[len(ret.moves)-1].Comments, strings.TrimSpace(commentText))
 		}
 
 		if move != "" {
-			moves = append(moves, moveWithComment{MoveStr: move})
+			ret.moves = append(ret.moves, moveWithComment{MoveStr: move})
 		}
 	}
-	return moves, outcome, nil
+	return ret, nil
 }
 
 func stripTagPairs(pgn string) string {

--- a/pgn_test.go
+++ b/pgn_test.go
@@ -190,6 +190,41 @@ func TestScannerWithNested(t *testing.T) {
 	}
 }
 
+func TestScannerWithNestedAndExpand(t *testing.T) {
+	fname := "fixtures/pgns/0013.pgn"
+	f, err := os.Open(fname)
+	if err != nil {
+		panic(err)
+	}
+	defer f.Close()
+
+	scannerOpts := ScannerOpts{ExpandVariations: true}
+	scanner := NewScannerWithOptions(f, scannerOpts)
+	games := []*Game{}
+	for scanner.Scan() {
+		err = scanner.Err()
+		if err != nil && err != io.EOF {
+			t.Fatalf(fname+" Unexpected non-nil/non-EOF err %v", err)
+		}
+		game := scanner.Next()
+		moveList := game.Moves()
+		if len(moveList) == 0 {
+			continue
+		}
+		games = append(games, game)
+	}
+	err = scanner.Err()
+	if err != io.EOF {
+		t.Fatalf(fname+" Unexpected non-EOF err %v", err)
+	}
+	if len(games) != 10 {
+		for idx, g := range games {
+			fmt.Printf("Parsed game %v: %v\n\n", idx, g)
+		}
+		t.Fatalf(fname+" expected 10 games but got %d", len(games))
+	}
+}
+
 func BenchmarkPGN(b *testing.B) {
 	pgn := mustParsePGN("fixtures/pgns/0001.pgn")
 	b.ResetTimer()

--- a/pgn_test.go
+++ b/pgn_test.go
@@ -1,6 +1,8 @@
 package chess
 
 import (
+	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
 	"strings"
@@ -151,6 +153,40 @@ func TestScanner(t *testing.T) {
 		if len(games) != 5 {
 			t.Fatalf(fname+" expected 5 games but got %d", len(games))
 		}
+	}
+}
+
+func TestScannerWithNested(t *testing.T) {
+	fname := "fixtures/pgns/0013.pgn"
+	f, err := os.Open(fname)
+	if err != nil {
+		panic(err)
+	}
+	defer f.Close()
+
+	scanner := NewScanner(f)
+	games := []*Game{}
+	for scanner.Scan() {
+		err = scanner.Err()
+		if err != nil && err != io.EOF {
+			t.Fatalf(fname+" Unexpected non-nil/non-EOF err %v", err)
+		}
+		game := scanner.Next()
+		moveList := game.Moves()
+		if len(moveList) == 0 {
+			continue
+		}
+		games = append(games, game)
+	}
+	err = scanner.Err()
+	if err != io.EOF {
+		t.Fatalf(fname+" Unexpected non-EOF err %v", err)
+	}
+	if len(games) != 3 {
+		for idx, g := range games {
+			fmt.Printf("Parsed game %v: %v\n\n", idx, g)
+		}
+		t.Fatalf(fname+" expected 3 games but got %d", len(games))
 	}
 }
 


### PR DESCRIPTION
Note this PR depends on prior PR: https://github.com/notnil/chess/pull/125

This series of commits adds an optional ability to expand variations when utilizing Scanner to iterate over a .pgn file. This is done by introducing an optional ScannerOpts where consumers of Scanner can specify different scanning behavior, beginning with an ExpandVariations option. When ExpandVariations==true, rather than create a single Game instance when scanning over a single game in a .pgn file, Scanner will instead create 1 Game instance per variation.