### PR TITLE
PGN-Spy clears the hash before evaluting the specific move

### DIFF
--- a/game.go
+++ b/game.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 )
 
 // A Outcome is the result of a game.
@@ -82,11 +81,26 @@ type Game struct {
 // function is designed to be used in the NewGame constructor.
 // An error is returned if there is a problem parsing the PGN data.
 func PGN(r io.Reader) (func(*Game), error) {
-	b, err := ioutil.ReadAll(r)
+	b, err := io.ReadAll(r)
 	if err != nil {
 		return nil, err
 	}
 	game, err := decodePGN(string(b))
+	if err != nil {
+		return nil, err
+	}
+	return func(g *Game) {
+		g.copy(game)
+	}, nil
+}
+
+// PGNFromString takes a pgn string and returns a function that updates
+// the game to reflect the PGN data.  The PGN can use any
+// move notation supported by this package.  The returned
+// function is designed to be used in the NewGame constructor.
+// An error is returned if there is a problem parsing the PGN data.
+func PGNFromString(pgn string) (func(*Game), error) {
+	game, err := decodePGN(pgn)
 	if err != nil {
 		return nil, err
 	}

--- a/game.go
+++ b/game.go
@@ -154,9 +154,9 @@ func NewGame(options ...func(*Game)) *Game {
 	return game
 }
 
-// Move updates the game with the given move.  An error is returned
+// MoveWithComments updates the game with the given move and set comments. An error is returned
 // if the move is invalid or the game has already been completed.
-func (g *Game) Move(m *Move) error {
+func (g *Game) MoveWithComments(m *Move, comments []string) error {
 	valid := moveSlice(g.ValidMoves()).find(m)
 	if valid == nil {
 		return fmt.Errorf("chess: invalid move %s", m)
@@ -165,7 +165,14 @@ func (g *Game) Move(m *Move) error {
 	g.pos = g.pos.Update(valid)
 	g.positions = append(g.positions, g.pos)
 	g.updatePosition()
+	g.comments = append(g.comments, comments)
 	return nil
+}
+
+// Move updates the game with the given move.  An error is returned
+// if the move is invalid or the game has already been completed.
+func (g *Game) Move(m *Move) error {
+	return g.MoveWithComments(m, nil)
 }
 
 // MoveStr decodes the given string in game's notation
@@ -176,7 +183,18 @@ func (g *Game) MoveStr(s string) error {
 	if err != nil {
 		return err
 	}
-	return g.Move(m)
+	return g.MoveWithComments(m, nil)
+}
+
+// MoveStrWithComments decodes the given string in game's notation
+// and calls the Move function.  An error is returned if
+// the move can't be decoded or the move is invalid.
+func (g *Game) MoveStrWithComments(s string, comments []string) error {
+	m, err := g.notation.Decode(g.pos, s)
+	if err != nil {
+		return err
+	}
+	return g.MoveWithComments(m, comments)
 }
 
 // ValidMoves returns a list of valid moves in the

--- a/pgn.go
+++ b/pgn.go
@@ -171,10 +171,9 @@ func decodePGN(pgn string) (*Game, error) {
 		if err != nil {
 			return nil, fmt.Errorf("chess: pgn decode error %s on move %d", err.Error(), g.Position().moveCount)
 		}
-		if err := g.Move(m); err != nil {
+		if err := g.MoveWithComments(m, move.Comments); err != nil {
 			return nil, fmt.Errorf("chess: pgn invalid move error %s on move %d", err.Error(), g.Position().moveCount)
 		}
-		g.comments = append(g.comments, move.Comments)
 	}
 	g.outcome = outcome
 	return g, nil

--- a/uci/cmd.go
+++ b/uci/cmd.go
@@ -125,11 +125,12 @@ var (
 // The substrings "value" and "name" should be avoided in  and  to allow unambiguous parsing,
 // for example do not use  = "draw value".
 // Here are some strings for the example below:
-//    "setoption name Nullmove value true\n"
-//   "setoption name Selectivity value 3\n"
-//    "setoption name Style value Risky\n"
-//    "setoption name Clear Hash\n"
-//    "setoption name NalimovPath value c:\chess\tb\4;c:\chess\tb\5\n"
+//
+//	 "setoption name Nullmove value true\n"
+//	"setoption name Selectivity value 3\n"
+//	 "setoption name Style value Risky\n"
+//	 "setoption name Clear Hash\n"
+//	 "setoption name NalimovPath value c:\chess\tb\4;c:\chess\tb\5\n"
 type CmdSetOption struct {
 	Name  string
 	Value string
@@ -179,42 +180,42 @@ func (CmdPosition) ProcessResponse(e *Engine) error {
 // start calculating on the current position set up with the "position" command.
 // There are a number of commands that can follow this command, all will be sent in the same string.
 // If one command is not send its value should be interpreted as it would not influence the search.
-// * searchmoves  ....
-// 	restrict search to this moves only
-// 	Example: After "position startpos" and "go infinite searchmoves e2e4 d2d4"
-// 	the engine should only search the two moves e2e4 and d2d4 in the initial position.
-// * ponder
-// 	start searching in pondering mode.
-// 	Do not exit the search in ponder mode, even if it's mate!
-// 	This means that the last move sent in in the position string is the ponder move.
-// 	The engine can do what it wants to do, but after a "ponderhit" command
-// 	it should execute the suggested move to ponder on. This means that the ponder move sent by
-// 	the GUI can be interpreted as a recommendation about which move to ponder. However, if the
-// 	engine decides to ponder on a different move, it should not display any mainlines as they are
-// 	likely to be misinterpreted by the GUI because the GUI expects the engine to ponder
-//    on the suggested move.
-// * wtime
-// 	white has x msec left on the clock
-// * btime
-// 	black has x msec left on the clock
-// * winc
-// 	white increment per move in mseconds if x > 0
-// * binc
-// 	black increment per move in mseconds if x > 0
-// * movestogo
-//   there are x moves to the next time control,
-// 	this will only be sent if x > 0,
-// 	if you don't get this and get the wtime and btime it's sudden death
-// * depth
-// 	search x plies only.
-// * nodes
-//    search x nodes only,
-// * mate
-// 	search for a mate in x moves
-// * movetime
-// 	search exactly x mseconds
-// * infinite
-// 	search until the "stop" command. Do not exit the search without being told so in this mode!
+//   - searchmoves  ....
+//     restrict search to this moves only
+//     Example: After "position startpos" and "go infinite searchmoves e2e4 d2d4"
+//     the engine should only search the two moves e2e4 and d2d4 in the initial position.
+//   - ponder
+//     start searching in pondering mode.
+//     Do not exit the search in ponder mode, even if it's mate!
+//     This means that the last move sent in in the position string is the ponder move.
+//     The engine can do what it wants to do, but after a "ponderhit" command
+//     it should execute the suggested move to ponder on. This means that the ponder move sent by
+//     the GUI can be interpreted as a recommendation about which move to ponder. However, if the
+//     engine decides to ponder on a different move, it should not display any mainlines as they are
+//     likely to be misinterpreted by the GUI because the GUI expects the engine to ponder
+//     on the suggested move.
+//   - wtime
+//     white has x msec left on the clock
+//   - btime
+//     black has x msec left on the clock
+//   - winc
+//     white increment per move in mseconds if x > 0
+//   - binc
+//     black increment per move in mseconds if x > 0
+//   - movestogo
+//     there are x moves to the next time control,
+//     this will only be sent if x > 0,
+//     if you don't get this and get the wtime and btime it's sudden death
+//   - depth
+//     search x plies only.
+//   - nodes
+//     search x nodes only,
+//   - mate
+//     search for a mate in x moves
+//   - movetime
+//     search exactly x mseconds
+//   - infinite
+//     search until the "stop" command. Do not exit the search without being told so in this mode!
 type CmdGo struct {
 	SearchMoves    []*chess.Move
 	Ponder         bool
@@ -304,7 +305,7 @@ func (CmdGo) ProcessResponse(e *Engine) error {
 		info := &Info{}
 		err := info.UnmarshalText([]byte(text))
 		if err == nil {
-			results.Info = *info
+			results.Infos = append(results.Infos, *info)
 		}
 	}
 	e.results = results
@@ -312,7 +313,7 @@ func (CmdGo) ProcessResponse(e *Engine) error {
 }
 
 func parseIDLine(s string) (string, string, error) {
-	if strings.HasPrefix(s, "id") == false {
+	if !strings.HasPrefix(s, "id") {
 		return "", "", errors.New("uci: invalid id line")
 	}
 	parts := strings.Split(s, " ")

--- a/uci/cmd.go
+++ b/uci/cmd.go
@@ -282,6 +282,13 @@ func (CmdGo) ProcessResponse(e *Engine) error {
 	results := SearchResults{}
 	for scanner.Scan() {
 		text := e.readLine(scanner)
+
+		info := &Info{}
+		err := info.UnmarshalText([]byte(text))
+		if err == nil {
+			results.Infos = append(results.Infos, *info)
+		}
+
 		if strings.HasPrefix(text, "bestmove") {
 			parts := strings.Split(text, " ")
 			if len(parts) <= 1 {
@@ -300,12 +307,6 @@ func (CmdGo) ProcessResponse(e *Engine) error {
 				results.Ponder = ponderMove
 			}
 			break
-		}
-
-		info := &Info{}
-		err := info.UnmarshalText([]byte(text))
-		if err == nil {
-			results.Infos = append(results.Infos, *info)
 		}
 	}
 	e.results = results

--- a/uci/cmd.go
+++ b/uci/cmd.go
@@ -129,7 +129,6 @@ var (
 //	 "setoption name Nullmove value true\n"
 //	"setoption name Selectivity value 3\n"
 //	 "setoption name Style value Risky\n"
-//	 "setoption name Clear Hash\n"
 //	 "setoption name NalimovPath value c:\chess\tb\4;c:\chess\tb\5\n"
 type CmdSetOption struct {
 	Name  string
@@ -142,6 +141,21 @@ func (cmd CmdSetOption) String() string {
 
 // ProcessResponse implements the Cmd interface
 func (cmd CmdSetOption) ProcessResponse(e *Engine) error {
+	return nil
+}
+
+// CmdClearHash corresponds to the "setoption name clear hash" command:
+//
+//	"setoption name Clear Hash\n"
+type CmdSetOptionClearHash struct {
+}
+
+func (cmd CmdSetOptionClearHash) String() string {
+	return fmt.Sprintf("setoption name clear hash")
+}
+
+// ProcessResponse implements the Cmd interface
+func (cmd CmdSetOptionClearHash) ProcessResponse(e *Engine) error {
 	return nil
 }
 

--- a/uci/info.go
+++ b/uci/info.go
@@ -16,73 +16,75 @@ import (
 type SearchResults struct {
 	BestMove *chess.Move
 	Ponder   *chess.Move
-	Info     Info
+	Infos    []Info
 }
 
 // Info corresponds to the "info" engine output:
 // the engine wants to send infos to the GUI. This should be done whenever one of the info has changed.
 // The engine can send only selected infos and multiple infos can be send with one info command,
 // e.g. "info currmove e2e4 currmovenumber 1" or
-// 	 "info depth 12 nodes 123456 nps 100000".
+//
+//	"info depth 12 nodes 123456 nps 100000".
+//
 // Also all infos belonging to the pv should be sent together
 // e.g. "info depth 2 score cp 214 time 1242 nodes 2124 nps 34928 pv e2e4 e7e5 g1f3"
 // I suggest to start sending "currmove", "currmovenumber", "currline" and "refutation" only after one second
 // to avoid too much traffic.
 // Additional info:
-// * depth
-// 	search depth in plies
-// * seldepth
-// 	selective search depth in plies,
-// 	if the engine sends seldepth there must also a "depth" be present in the same string.
-// * time
-// 	the time searched in ms, this should be sent together with the pv.
-// * nodes
-// 	x nodes searched, the engine should send this info regularly
-// * pv  ...
-// 	the best line found
-// * multipv
-// 	this for the multi pv mode.
-// 	for the best move/pv add "multipv 1" in the string when you send the pv.
-// 	in k-best mode always send all k variants in k strings together.
-// * score
-// 	* cp
-// 		the score from the engine's point of view in centipawns.
-// 	* mate
-// 		mate in y moves, not plies.
-// 		If the engine is getting mated use negativ values for y.
-// 	* lowerbound
-// 	  the score is just a lower bound.
-// 	* upperbound
-// 	   the score is just an upper bound.
-// * currmove
-// 	currently searching this move
-// * currmovenumber
-// 	currently searching move number x, for the first move x should be 1 not 0.
-// * hashfull
-// 	the hash is x permill full, the engine should send this info regularly
-// * nps
-// 	x nodes per second searched, the engine should send this info regularly
-// * tbhits
-// 	x positions where found in the endgame table bases
-// * cpuload
-// 	the cpu usage of the engine is x permill.
-// * string
-// 	any string str which will be displayed be the engine,
-// 	if there is a string command the rest of the line will be interpreted as .
-// * refutation   ...
-//    move  is refuted by the line  ... , i can be any number >= 1.
-//    Example: after move d1h5 is searched, the engine can send
-//    "info refutation d1h5 g6h5"
-//    if g6h5 is the best answer after d1h5 or if g6h5 refutes the move d1h5.
-//    if there is norefutation for d1h5 found, the engine should just send
-//    "info refutation d1h5"
-// 	The engine should only send this if the option "UCI_ShowRefutations" is set to true.
-// * currline   ...
-//    this is the current line the engine is calculating.  is the number of the cpu if
-//    the engine is running on more than one cpu.  = 1,2,3....
-//    if the engine is just using one cpu,  can be omitted.
-//    If  is greater than 1, always send all k lines in k strings together.
-// 	The engine should only send this if the option "UCI_ShowCurrLine" is set to true.
+//   - depth
+//     search depth in plies
+//   - seldepth
+//     selective search depth in plies,
+//     if the engine sends seldepth there must also a "depth" be present in the same string.
+//   - time
+//     the time searched in ms, this should be sent together with the pv.
+//   - nodes
+//     x nodes searched, the engine should send this info regularly
+//   - pv  ...
+//     the best line found
+//   - multipv
+//     this for the multi pv mode.
+//     for the best move/pv add "multipv 1" in the string when you send the pv.
+//     in k-best mode always send all k variants in k strings together.
+//   - score
+//   - cp
+//     the score from the engine's point of view in centipawns.
+//   - mate
+//     mate in y moves, not plies.
+//     If the engine is getting mated use negativ values for y.
+//   - lowerbound
+//     the score is just a lower bound.
+//   - upperbound
+//     the score is just an upper bound.
+//   - currmove
+//     currently searching this move
+//   - currmovenumber
+//     currently searching move number x, for the first move x should be 1 not 0.
+//   - hashfull
+//     the hash is x permill full, the engine should send this info regularly
+//   - nps
+//     x nodes per second searched, the engine should send this info regularly
+//   - tbhits
+//     x positions where found in the endgame table bases
+//   - cpuload
+//     the cpu usage of the engine is x permill.
+//   - string
+//     any string str which will be displayed be the engine,
+//     if there is a string command the rest of the line will be interpreted as .
+//   - refutation   ...
+//     move  is refuted by the line  ... , i can be any number >= 1.
+//     Example: after move d1h5 is searched, the engine can send
+//     "info refutation d1h5 g6h5"
+//     if g6h5 is the best answer after d1h5 or if g6h5 refutes the move d1h5.
+//     if there is norefutation for d1h5 found, the engine should just send
+//     "info refutation d1h5"
+//     The engine should only send this if the option "UCI_ShowRefutations" is set to true.
+//   - currline   ...
+//     this is the current line the engine is calculating.  is the number of the cpu if
+//     the engine is running on more than one cpu.  = 1,2,3....
+//     if the engine is just using one cpu,  can be omitted.
+//     If  is greater than 1, always send all k lines in k strings together.
+//     The engine should only send this if the option "UCI_ShowCurrLine" is set to true.
 type Info struct {
 	Depth             int
 	Seldepth          int
@@ -100,16 +102,16 @@ type Info struct {
 }
 
 // Score corresponds to the "info"'s score engine output:
-// * score
-// * cp
-// 	the score from the engine's point of view in centipawns.
-// * mate
-// 	mate in y moves, not plies.
-// 	If the engine is getting mated use negativ values for y.
-// * lowerbound
-//   the score is just a lower bound.
-// * upperbound
-//    the score is just an upper bound.
+//   - score
+//   - cp
+//     the score from the engine's point of view in centipawns.
+//   - mate
+//     mate in y moves, not plies.
+//     If the engine is getting mated use negativ values for y.
+//   - lowerbound
+//     the score is just a lower bound.
+//   - upperbound
+//     the score is just an upper bound.
 type Score struct {
 	CP         int
 	Mate       int


### PR DESCRIPTION
When the move the player plays is not in the top X moves list, PGN-Spy has to issue a new search command to discover what the evaluation of a given move actually is. When doing so, it will [clear the hash](https://github.com/MGleason1/PGN-Spy/blob/54aa66e4824b354da2471b5c503d0b17de881273/uci-analyser/analyse.cpp#L521) and we need to do the same. 

The current `CmdSetOption` will produce a UCI command of `setoption name clear value hash` when the command needs to be `   `setoption name clear hash` as per [this line](https://github.com/MGleason1/PGN-Spy/blob/master/uci-analyser/engine.cpp#L41C1-L41C38).

This PR adds a new command for clearing the hash.