### PR TITLE
Add dark mode & perspective to Board.Draw()

### DIFF
--- a/board.go
+++ b/board.go
@@ -108,6 +108,22 @@ func (b *Board) Transpose() *Board {
 
 // Draw returns visual representation of the board useful for debugging.
 func (b *Board) Draw() string {
+	return b.drawForWhite(false)
+}
+
+// Draw2 returns visual representation of the board useful for debugging.
+// It is similar to Draw() except allows the caller to specify perspective
+// and dark mode options
+func (b *Board) Draw2(perspective Color, darkMode bool) string {
+	if perspective == Black {
+		return b.drawForBlack(darkMode)
+	} // else
+
+	return b.drawForWhite(darkMode)
+}
+
+// drawForWhite returns visual representation of the board from white's perspective
+func (b *Board) drawForWhite(darkMode bool) string {
 	s := "\n A B C D E F G H\n"
 	for r := 7; r >= 0; r-- {
 		s += Rank(r).String()
@@ -116,7 +132,34 @@ func (b *Board) Draw() string {
 			if p == NoPiece {
 				s += "-"
 			} else {
-				s += p.String()
+				if darkMode {
+					s += p.DarkString()
+				} else {
+					s += p.String()
+				}
+			}
+			s += " "
+		}
+		s += "\n"
+	}
+	return s
+}
+
+// drawForBlack returns visual representation of the board from black's perspective
+func (b *Board) drawForBlack(darkMode bool) string {
+	s := "\n H G F E D C B A\n"
+	for r := 0; r <= 7; r++ {
+		s += Rank(r).String()
+		for f := numOfSquaresInRow - 1; f >= 0; f-- {
+			p := b.Piece(NewSquare(File(f), Rank(r)))
+			if p == NoPiece {
+				s += "-"
+			} else {
+				if darkMode {
+					s += p.DarkString()
+				} else {
+					s += p.String()
+				}
 			}
 			s += " "
 		}

--- a/piece.go
+++ b/piece.go
@@ -174,8 +174,13 @@ func (p Piece) String() string {
 	return pieceUnicodes[int(p)]
 }
 
+func (p Piece) DarkString() string {
+	return pieceDarkUnicodes[int(p)]
+}
+
 var (
-	pieceUnicodes = []string{" ", "♔", "♕", "♖", "♗", "♘", "♙", "♚", "♛", "♜", "♝", "♞", "♟"}
+	pieceUnicodes     = []string{" ", "♔", "♕", "♖", "♗", "♘", "♙", "♚", "♛", "♜", "♝", "♞", "♟"}
+	pieceDarkUnicodes = []string{" ", "♚", "♛", "♜", "♝", "♞", "♟", "♔", "♕", "♖", "♗", "♘", "♙"}
 )
 
 func (p Piece) getFENChar() string {


### PR DESCRIPTION
This commit adds Board.Draw2(perspective Color, darkMode bool). This is similar to Board.Draw() except that it allows the caller to specify from which perspective to display and whether the display should be reversed colors. (In a terminal window configured with white foreground text and a black background, the current Board.Draw() displays the opposite color).

(cherry picked from commit 2c91017f4920b7de4f3967ea9274f93955826fa6) (cherry picked from commit 820a54f8c17c34550e649e79c144bfefbb004b83)