### PR TITLE
Speedup FEN generation

### DIFF
--- a/board.go
+++ b/board.go
@@ -8,6 +8,16 @@ import (
 	"strings"
 )
 
+var fenReplacer = strings.NewReplacer(
+	"11111111", "8",
+	"1111111", "7",
+	"111111", "6",
+	"11111", "5",
+	"1111", "4",
+	"111", "3",
+	"11", "2",
+)
+
 // A Board represents a chess board and its relationship between squares and pieces.
 type Board struct {
 	bbWhiteKing   bitboard
@@ -149,6 +159,51 @@ func (b *Board) String() string {
 		fen = strings.Replace(fen, repeatStr, countStr, -1)
 	}
 	return fen
+}
+
+func (b *Board) StringV2() string {
+	var fenBuilder strings.Builder
+	for r := 7; r >= 0; r-- {
+		for f := 0; f < numOfSquaresInRow; f++ {
+			sq := NewSquare(File(f), Rank(r))
+			p := b.Piece(sq)
+			if p != NoPiece {
+				fenBuilder.WriteString(p.getFENChar())
+			} else {
+				fenBuilder.WriteString("1")
+			}
+		}
+		if r != 0 {
+			fenBuilder.WriteString("/")
+		}
+	}
+	fen := fenBuilder.String()
+	for i := 8; i > 1; i-- {
+		repeatStr := strings.Repeat("1", i)
+		countStr := strconv.Itoa(i)
+		fen = strings.Replace(fen, repeatStr, countStr, -1)
+	}
+	return fen
+}
+
+func (b *Board) StringV3() string {
+	var fenBuilder strings.Builder
+	for r := 7; r >= 0; r-- {
+		for f := 0; f < numOfSquaresInRow; f++ {
+			sq := NewSquare(File(f), Rank(r))
+			p := b.Piece(sq)
+			if p != NoPiece {
+				fenBuilder.WriteString(p.getFENChar())
+			} else {
+				fenBuilder.WriteString("1")
+			}
+		}
+		if r != 0 {
+			fenBuilder.WriteString("/")
+		}
+	}
+
+	return fenReplacer.Replace(fenBuilder.String())
 }
 
 // Piece returns the piece for the given square.

--- a/board.go
+++ b/board.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/binary"
 	"errors"
-	"strconv"
 	"strings"
 )
 
@@ -138,55 +137,6 @@ func (b *Board) Draw() string {
 // String implements the fmt.Stringer interface and returns
 // a string in the FEN board format: rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR
 func (b *Board) String() string {
-	fen := ""
-	for r := 7; r >= 0; r-- {
-		for f := 0; f < numOfSquaresInRow; f++ {
-			sq := NewSquare(File(f), Rank(r))
-			p := b.Piece(sq)
-			if p != NoPiece {
-				fen += p.getFENChar()
-			} else {
-				fen += "1"
-			}
-		}
-		if r != 0 {
-			fen += "/"
-		}
-	}
-	for i := 8; i > 1; i-- {
-		repeatStr := strings.Repeat("1", i)
-		countStr := strconv.Itoa(i)
-		fen = strings.Replace(fen, repeatStr, countStr, -1)
-	}
-	return fen
-}
-
-func (b *Board) StringV2() string {
-	var fenBuilder strings.Builder
-	for r := 7; r >= 0; r-- {
-		for f := 0; f < numOfSquaresInRow; f++ {
-			sq := NewSquare(File(f), Rank(r))
-			p := b.Piece(sq)
-			if p != NoPiece {
-				fenBuilder.WriteString(p.getFENChar())
-			} else {
-				fenBuilder.WriteString("1")
-			}
-		}
-		if r != 0 {
-			fenBuilder.WriteString("/")
-		}
-	}
-	fen := fenBuilder.String()
-	for i := 8; i > 1; i-- {
-		repeatStr := strings.Repeat("1", i)
-		countStr := strconv.Itoa(i)
-		fen = strings.Replace(fen, repeatStr, countStr, -1)
-	}
-	return fen
-}
-
-func (b *Board) StringV3() string {
 	var fenBuilder strings.Builder
 	for r := 7; r >= 0; r-- {
 		for f := 0; f < numOfSquaresInRow; f++ {

--- a/board_test.go
+++ b/board_test.go
@@ -5,17 +5,66 @@ import (
 )
 
 func TestBoardTextSerialization(t *testing.T) {
+	for _, fen := range []string{
+		"rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR",
+		"rnbqkb1r/pp1p1np1/4pp2/2pP3p/8/2N2NP1/PPP1PP1P/R1BQKBR1",
+	} {
+		t.Run(fen, func(t *testing.T) {
+			b := &Board{}
+			if err := b.UnmarshalText([]byte(fen)); err != nil {
+				t.Fatal("recieved unexpected error", err)
+			}
+			txt, err := b.MarshalText()
+			if err != nil {
+				t.Fatal("recieved unexpected error", err)
+			}
+			if fen != string(txt) {
+				t.Fatalf("fen expected board string %s but got %s", fen, string(txt))
+			}
+			other := b.StringV2()
+			if fen != string(other) {
+				t.Fatalf("fen expected board string %s but got %s", fen, string(txt))
+			}
+
+			other = b.StringV3()
+			if fen != string(other) {
+				t.Fatalf("fen expected board string %s but got %s", fen, string(txt))
+			}
+		})
+	}
+
+}
+
+func BenchmarkTextSerialization(b *testing.B) {
 	fen := "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR"
-	b := &Board{}
-	if err := b.UnmarshalText([]byte(fen)); err != nil {
-		t.Fatal("recieved unexpected error", err)
+	board := &Board{}
+	if err := board.UnmarshalText([]byte(fen)); err != nil {
+		b.Fatal("recieved unexpected error", err)
 	}
-	txt, err := b.MarshalText()
-	if err != nil {
-		t.Fatal("recieved unexpected error", err)
+	for i := 0; i < b.N; i++ {
+		board.String()
 	}
-	if fen != string(txt) {
-		t.Fatalf("fen expected board string %s but got %s", fen, string(txt))
+}
+
+func BenchmarkTextSerializationV2(b *testing.B) {
+	fen := "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR"
+	board := &Board{}
+	if err := board.UnmarshalText([]byte(fen)); err != nil {
+		b.Fatal("recieved unexpected error", err)
+	}
+	for i := 0; i < b.N; i++ {
+		board.StringV2()
+	}
+}
+
+func BenchmarkTextSerializationV3(b *testing.B) {
+	fen := "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR"
+	board := &Board{}
+	if err := board.UnmarshalText([]byte(fen)); err != nil {
+		b.Fatal("recieved unexpected error", err)
+	}
+	for i := 0; i < b.N; i++ {
+		board.StringV3()
 	}
 }
 

--- a/board_test.go
+++ b/board_test.go
@@ -21,21 +21,12 @@ func TestBoardTextSerialization(t *testing.T) {
 			if fen != string(txt) {
 				t.Fatalf("fen expected board string %s but got %s", fen, string(txt))
 			}
-			other := b.StringV2()
-			if fen != string(other) {
-				t.Fatalf("fen expected board string %s but got %s", fen, string(txt))
-			}
-
-			other = b.StringV3()
-			if fen != string(other) {
-				t.Fatalf("fen expected board string %s but got %s", fen, string(txt))
-			}
 		})
 	}
 
 }
 
-func BenchmarkTextSerialization(b *testing.B) {
+func BenchmarkBoardTextSerialization(b *testing.B) {
 	fen := "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR"
 	board := &Board{}
 	if err := board.UnmarshalText([]byte(fen)); err != nil {
@@ -43,28 +34,6 @@ func BenchmarkTextSerialization(b *testing.B) {
 	}
 	for i := 0; i < b.N; i++ {
 		board.String()
-	}
-}
-
-func BenchmarkTextSerializationV2(b *testing.B) {
-	fen := "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR"
-	board := &Board{}
-	if err := board.UnmarshalText([]byte(fen)); err != nil {
-		b.Fatal("recieved unexpected error", err)
-	}
-	for i := 0; i < b.N; i++ {
-		board.StringV2()
-	}
-}
-
-func BenchmarkTextSerializationV3(b *testing.B) {
-	fen := "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR"
-	board := &Board{}
-	if err := board.UnmarshalText([]byte(fen)); err != nil {
-		b.Fatal("recieved unexpected error", err)
-	}
-	for i := 0; i < b.N; i++ {
-		board.StringV3()
 	}
 }
 

--- a/board_test.go
+++ b/board_test.go
@@ -32,6 +32,8 @@ func BenchmarkBoardTextSerialization(b *testing.B) {
 	if err := board.UnmarshalText([]byte(fen)); err != nil {
 		b.Fatal("recieved unexpected error", err)
 	}
+
+	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		board.String()
 	}

--- a/fen.go
+++ b/fen.go
@@ -137,9 +137,18 @@ var (
 		"n": BlackKnight,
 		"p": BlackPawn,
 	}
+	pieceFenMap = reversePieceMap()
 
 	fenTurnMap = map[string]Color{
 		"w": White,
 		"b": Black,
 	}
 )
+
+func reversePieceMap() map[Piece]string {
+	res := make(map[Piece]string)
+	for k, v := range fenPieceMap {
+		res[v] = k
+	}
+	return res
+}

--- a/piece.go
+++ b/piece.go
@@ -179,10 +179,9 @@ var (
 )
 
 func (p Piece) getFENChar() string {
-	for key, piece := range fenPieceMap {
-		if piece == p {
-			return key
-		}
+	res, ok := pieceFenMap[p]
+	if !ok {
+		return ""
 	}
-	return ""
+	return res
 }


### PR DESCRIPTION
Hello.

I propose multiple changes that should, as I believe, improve code style with using more idiomatic approaches. This also significantly improves performance for FEN generation. I believe that this method is really important because it's the only standard positions representation.

Before: (benchmark was added, but code is the same)
```
BenchmarkBoardTextSerialization-16        179582              6439 ns/op
```

After
```
BenchmarkBoardTextSerialization-16        593695              1892 ns/op
```

About **3.4x** boost.